### PR TITLE
fix: Contributor link extending to entire row

### DIFF
--- a/src/pages/c/[configKind]/[tip].astro
+++ b/src/pages/c/[configKind]/[tip].astro
@@ -110,7 +110,7 @@ const breadCrumbList: BreadCrumbList = [
     <footer class="flex flex-col gap-2 mt-2 text-sm text-gray-500">
       <section>
         <h2 class="text-gray-500 font-medium">Contributor:</h2>
-        <figure>
+        <figure class="inline-block">
           <Link
             href={contributor.url}
             className="flex flex-row items-center gap-2 hover:text-indigo-300 duration-150"

--- a/src/pages/c/[configKind]/[tip].astro
+++ b/src/pages/c/[configKind]/[tip].astro
@@ -110,10 +110,10 @@ const breadCrumbList: BreadCrumbList = [
     <footer class="flex flex-col gap-2 mt-2 text-sm text-gray-500">
       <section>
         <h2 class="text-gray-500 font-medium">Contributor:</h2>
-        <figure class="inline-block pr-2">
+        <figure class="inline-block>
           <Link
             href={contributor.url}
-            className="flex flex-row items-center gap-2 hover:text-indigo-300 duration-150"
+            className="flex flex-row items-center gap-2 hover:text-indigo-300 duration-150 pr-2""
           >
             <img
               src={contributor.image}

--- a/src/pages/c/[configKind]/[tip].astro
+++ b/src/pages/c/[configKind]/[tip].astro
@@ -110,7 +110,7 @@ const breadCrumbList: BreadCrumbList = [
     <footer class="flex flex-col gap-2 mt-2 text-sm text-gray-500">
       <section>
         <h2 class="text-gray-500 font-medium">Contributor:</h2>
-        <figure class="inline-block">
+        <figure class="inline-block pr-2">
           <Link
             href={contributor.url}
             className="flex flex-row items-center gap-2 hover:text-indigo-300 duration-150"


### PR DESCRIPTION
## Changes

This PR adds the `inline-block` class to the figure component to prevent the component's content from taking space in the entire row.

More info at: https://tailwindcss.com/docs/display#block-and-inline