### PR TITLE
refactor: github api utils

### DIFF
--- a/src/components/UI/ContributorList/ContributorList.astro
+++ b/src/components/UI/ContributorList/ContributorList.astro
@@ -1,4 +1,5 @@
 ---
+import { getContributors } from "../../../../utils/githubAPI";
 import Link from "../../Link.astro";
 
 interface Props {
@@ -13,12 +14,6 @@ interface Props {
   };
 }
 
-type GitContributor = {
-  login: string;
-  avatar_url: string;
-  html_url: string;
-  contributions: number;
-};
 
 const { gh_slug, max = 9999, classNames } = Astro.props;
 
@@ -30,21 +25,8 @@ const classNamesSetup = {
   img: classNames?.img ?? '',
 };
 
-const api = (slug: string) => {
-  return `https://api.github.com/repos/${slug}/contributors`;
-};
+const contributors = await getContributors(gh_slug)
 
-const getContributors = async (slug: string): Promise<GitContributor[]> => {
-  const res = await fetch(api(slug));
-  const data = await res.json();
-  if (!Array.isArray(data)) {
-    console.log(data);
-    throw new Error("Invalid response");
-  }
-  return data as GitContributor[];
-};
-
-const contributors = await getContributors(gh_slug);
 ---
 
 <div class={classNamesSetup.root}>

--- a/utils/githubAPI.ts
+++ b/utils/githubAPI.ts
@@ -1,8 +1,59 @@
-export function getContributor(profileURL: string) {
-  const username = profileURL.split("/")[3];
+
+export type GitHubContributor = {
+  login: string;
+  avatar_url: string;
+  html_url: string;
+}
+
+type GitHubAPIResponseContributors = GitHubContributor[];
+
+/**
+ * This function does not require authentication
+ * @param profileURL - The URL of the GitHub profile to fetch data for
+ * @returns
+ */
+export function getContributor(profileURL: string): GitHubContributor {
+  const login = profileURL.split("/")[3]
+  if (!login) {
+    throw new Error(`Could not parse GitHub login from profile URL: ${profileURL}`);
+  }
   return {
-    username,
-    avatarURL: `https://github.com/${username}.png`,
-    profileURL,
+    login,
+    avatar_url: `${profileURL}.png`,
+    html_url: profileURL,
   };
+}
+
+/**
+ * Fetches all contributors to the repository
+ * Without authentication, this will be rate limited
+ */
+export async function getContributors(token?: string) {
+  const contributorsURL =
+    "https://api.github.com/repos/CircleCI-Public/Config.Tips/contributors";
+  let headers: Record<string, string> = {
+    Accept: "application/vnd.github.v3+json",
+  };
+  // Only add Authorization header if a token is provided
+  if (token) {
+    headers["Authorization"] = `token ${token}`;
+  }
+  const response = await fetch(contributorsURL, { headers });
+  if (!response.ok) {
+    throw new Error(
+      `Could not fetch contributors from GitHub API: ${response.statusText}`
+    );
+  }
+  try {
+    const contributors: GitHubAPIResponseContributors = await response.json();
+    return contributors.map((contributor) => {
+      return {
+        login: contributor.login,
+        avatar_url: contributor.avatar_url,
+        html_url: contributor.html_url,
+      };
+    });
+  } catch (error) {
+    throw new Error(`Could not parse contributors from GitHub API: ${error}`);
+  }
 }

--- a/utils/githubAPI.ts
+++ b/utils/githubAPI.ts
@@ -1,0 +1,8 @@
+export function getContributor(profileURL: string) {
+  const username = profileURL.split("/")[3];
+  return {
+    username,
+    avatarURL: `https://github.com/${username}.png`,
+    profileURL,
+  };
+}

--- a/utils/githubAPI.ts
+++ b/utils/githubAPI.ts
@@ -1,9 +1,8 @@
-
 export type GitHubContributor = {
   login: string;
   avatar_url: string;
   html_url: string;
-}
+};
 
 type GitHubAPIResponseContributors = GitHubContributor[];
 
@@ -13,9 +12,11 @@ type GitHubAPIResponseContributors = GitHubContributor[];
  * @returns
  */
 export function getContributor(profileURL: string): GitHubContributor {
-  const login = profileURL.split("/")[3]
+  const login = profileURL.split("/")[3];
   if (!login) {
-    throw new Error(`Could not parse GitHub login from profile URL: ${profileURL}`);
+    throw new Error(
+      `Could not parse GitHub login from profile URL: ${profileURL}`,
+    );
   }
   return {
     login,
@@ -29,8 +30,7 @@ export function getContributor(profileURL: string): GitHubContributor {
  * Without authentication, this will be rate limited
  */
 export async function getContributors(gh_slug: string, token?: string) {
-  const contributorsURL =
-    `https://api.github.com/repos/${gh_slug}/contributors`;
+  const contributorsURL = `https://api.github.com/repos/${gh_slug}/contributors`;
   let headers: Record<string, string> = {
     Accept: "application/vnd.github.v3+json",
   };
@@ -41,7 +41,7 @@ export async function getContributors(gh_slug: string, token?: string) {
   const response = await fetch(contributorsURL, { headers });
   if (!response.ok) {
     throw new Error(
-      `Could not fetch contributors from GitHub API: ${response.statusText}`
+      `Could not fetch contributors from GitHub API: ${response.statusText}`,
     );
   }
   try {

--- a/utils/githubAPI.ts
+++ b/utils/githubAPI.ts
@@ -28,9 +28,9 @@ export function getContributor(profileURL: string): GitHubContributor {
  * Fetches all contributors to the repository
  * Without authentication, this will be rate limited
  */
-export async function getContributors(token?: string) {
+export async function getContributors(gh_slug: string, token?: string) {
   const contributorsURL =
-    "https://api.github.com/repos/CircleCI-Public/Config.Tips/contributors";
+    `https://api.github.com/repos/${gh_slug}/contributors`;
   let headers: Record<string, string> = {
     Accept: "application/vnd.github.v3+json",
   };


### PR DESCRIPTION
This refactors common GitHub operations into a separate utility file and prepares us to eventually more easily make authenticated calls for fetching the contributors list in the future.