### PR TITLE
Fix typo in title of optimize-code-splitting-webpack-in-nextjs.md

### DIFF
--- a/src/content/tips/optimize-code-splitting-webpack-in-nextjs.md
+++ b/src/content/tips/optimize-code-splitting-webpack-in-nextjs.md
@@ -1,6 +1,6 @@
 ---
 kind: nextjs
-title: Optimize code splitting with Wepback
+title: Optimize code splitting with Webpack
 description: You can customize the Webpack configuration in Next.js to optimize your bundle size or making other advanced adjustments.
 contributor: https://github.com/rsylvian
 snippet: |


### PR DESCRIPTION
## Changes
* Change `wepback` typo to `webpack` in title

The URL/file name, description, and body were all correct already.
