### PR TITLE
docs(tip): add `package.json` tip to improve a prettier setup

### DIFF
--- a/src/content/tips/prettier-config-in-package-json.md
+++ b/src/content/tips/prettier-config-in-package-json.md
@@ -1,0 +1,15 @@
+---
+kind: package-json
+title: Set package-level Prettier configuration
+description: Keep the project's root folder clean while enforcing organization-wide codestyle.
+contributor: https://github.com/filiphsps
+snippet: |
+  {
+    "prettier": "@nordcom/prettier",
+    "scripts": {
+      "@nordcom/prettier": "0.1.1"
+    }
+  }
+---
+
+By setting the Prettier configuration directly in `package.json`, you avoid both the issue of saturating your workspace's root folder with another config file as well as arguably more importantly also completely eliminating inconsistencies in Prettier rules between projects.


### PR DESCRIPTION
Seen a lot of people get this wrong, so let's add a tip explaining the benefits of setting the prettier configuration in `package.json` rather than `.prettierrc` or `prettier.json`.